### PR TITLE
Summary responsive

### DIFF
--- a/component.json
+++ b/component.json
@@ -9,6 +9,8 @@
     "boot"
   ],
   "dependencies": {
-    "component/bus": "0.0.2"
+    "component/bus": "0.0.2",
+    "components/masonry": "^3.1.2",
+    "mjlescano/masonry": "^3.1.2"
   }
 }

--- a/lib/summary/component.json
+++ b/lib/summary/component.json
@@ -5,7 +5,8 @@
     "component/bus": "0.0.2",
     "component/dom": "0.7.1",
     "component/t": "1.0.0",
-    "component/indexof": "0.0.1"
+    "component/indexof": "0.0.1",
+    "mjlescano/masonry": "3.1.5"
   },
   "scripts": ["summary.js", "view.js"],
   "main": "summary.js",

--- a/lib/summary/summary.styl
+++ b/lib/summary/summary.styl
@@ -1,10 +1,24 @@
 #summary-container
-  h1, h4
+  h1,
+  h4
     text-align center
 
   h1
     text-transform uppercase
+
+  .laws
+    padding 0
+
   .bill-proposal
+    width 33.33%
+    padding 0 .5em
+
+    @media (max-width: 960px)
+      width 50%
+
+    @media (max-width: 500px)
+      width 100%
+
     .inner
       .author
         font-size .8em
@@ -14,7 +28,7 @@
         width 100%
         margin-bottom 1em
       .link
-        background url("/lib/bill-proposal-demo/images/clip.svg") no-repeat left 0.6em
+        background url('/lib/bill-proposal/images/clip.svg') no-repeat left 0.6em
         padding-left 1.7em
     .actions
       display none
@@ -44,6 +58,3 @@
   .share-message
     color #ccc
     font-weight bold
-
-// #browser
-//   overflow hidden

--- a/lib/summary/view.js
+++ b/lib/summary/view.js
@@ -5,9 +5,12 @@ var indexOf = require('indexof');
 var View = require('view');
 var template = require('./template');
 var BillProposal = require('bill-proposal');
+// var Masonry = require('masonry');
 
 function BillSummary(laws) {
-  var baseUrl = config.protocol + "://" + config.host + (config.publicPort ? (":" + config.publicPort) : "");
+  var baseUrl = config.protocol + "://" + config.host
+              + (config.publicPort ? (":" + config.publicPort) : "");
+
   View.call(this, template, {
     baseUrl: baseUrl,
     t: t,
@@ -15,11 +18,23 @@ function BillSummary(laws) {
   });
 
   var container = this.find('.laws');
+
   laws.forEach(function (law) {
     var billProposal = new BillProposal(law);
-    billProposal.el.addClass('col-md-4');
+    // billProposal.el.addClass('col-md-4');
     billProposal.appendTo(container[0]);
   })
+
+  $.getScript('//cdnjs.cloudflare.com/ajax/libs/masonry/3.1.5/masonry.pkgd.min.js')
+    .done(function(){
+      new Masonry(container[0], {
+        itemSelector: '.bill-proposal',
+        gutter: 0,
+        // containerStyle: null,
+        // visibleStyle: {},
+        // transitionDuration: 0
+      });
+    })
 }
 
 View(BillSummary);

--- a/lib/summary/view.js
+++ b/lib/summary/view.js
@@ -21,7 +21,6 @@ function BillSummary(laws) {
 
   laws.forEach(function (law) {
     var billProposal = new BillProposal(law);
-    // billProposal.el.addClass('col-md-4');
     billProposal.appendTo(container[0]);
   })
 
@@ -29,10 +28,7 @@ function BillSummary(laws) {
     .done(function(){
       new Masonry(container[0], {
         itemSelector: '.bill-proposal',
-        gutter: 0,
-        // containerStyle: null,
-        // visibleStyle: {},
-        // transitionDuration: 0
+        gutter: 0
       });
     })
 }


### PR DESCRIPTION
Hello!

Here's the functionality for a pinterest-like summary list. I used the [Masonry](http://masonry.desandro.com/) plugin, but couldn't make it work using it as a component (I even updated it: https://github.com/mjlescano/masonry), could you please revise it? Fairly sure it's something obvious that I'm not getting.

To make it work for now the lib is loading async in the file **/lib/summary/view.js**. (Yup' there's a $.getScript() in there :/)
